### PR TITLE
use whitelist for configparser dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
         - python
     run:
         - python
-        - configparser  # [not py35]
+        - configparser  # [py2k or py34]
 
 test:
     imports:


### PR DESCRIPTION
rather than 'not py35', since py36 and later will also not need it

fixes failure in #5